### PR TITLE
fixed bug for reading with size 0

### DIFF
--- a/serialram.cpp
+++ b/serialram.cpp
@@ -116,6 +116,11 @@ void SerialRam::begin(bool la, uint8_t pin, SerialRam::ESPISpeed speed)
 
 void SerialRam::read(char *buffer, uint32_t address, uint32_t size)
 {
+
+	if (size == 0) {
+		return;
+	}
+
     initTransfer(INSTR_READ);
     sendAddress(address);
 


### PR DESCRIPTION
this bug causes issues with your other library virtmem, when a read of size zero is tried it crashes the board.